### PR TITLE
Add ZIP code support for Los Angeles County

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ try:
     # Try to import reform capability
     try:
         from policyengine_core.reforms import Reform
+
         REFORM_AVAILABLE = True
     except ImportError:
         REFORM_AVAILABLE = False
@@ -30,33 +31,37 @@ try:
     st.set_page_config(
         page_title="Enhanced ACA Subsidies Calculator",
         layout="wide",
-        initial_sidebar_state="expanded"
+        initial_sidebar_state="expanded",
     )
 
 except Exception as e:
     st.error(f"Startup Error: {str(e)}")
     st.error("Please report this error with the details above.")
     import traceback
+
     st.code(traceback.format_exc())
     st.stop()
+
 
 # Load PolicyEngine logo
 def get_logo_base64():
     """Load PolicyEngine logo and convert to base64"""
     try:
-        with open('blue.png', 'rb') as f:
+        with open("blue.png", "rb") as f:
             return base64.b64encode(f.read()).decode()
     except:
         return None
+
 
 # Load counties from PolicyEngine data
 @st.cache_data
 def load_counties():
     try:
-        with open('counties.json', 'r') as f:
+        with open("counties.json", "r") as f:
             return json.load(f)
     except:
         return None
+
 
 # PolicyEngine brand colors
 COLORS = {
@@ -67,32 +72,37 @@ COLORS = {
     "blue_gradient": ["#D1E5F0", "#92C5DE", "#2166AC", "#053061"],
 }
 
+
 def get_logo_base64():
     """Get base64 encoded PolicyEngine logo"""
     try:
-        with open('blue.png', 'rb') as f:
+        with open("blue.png", "rb") as f:
             return base64.b64encode(f.read()).decode()
     except:
         return None
+
 
 def add_logo_to_layout():
     """Add PolicyEngine logo to chart layout (matches policyengine-app positioning)"""
     logo_base64 = get_logo_base64()
     if logo_base64:
         return {
-            "images": [{
-                "source": f"data:image/png;base64,{logo_base64}",
-                "xref": "paper",
-                "yref": "paper",
-                "x": 1.01,
-                "y": -0.18,
-                "sizex": 0.10,
-                "sizey": 0.10,
-                "xanchor": "right",
-                "yanchor": "bottom",
-            }]
+            "images": [
+                {
+                    "source": f"data:image/png;base64,{logo_base64}",
+                    "xref": "paper",
+                    "yref": "paper",
+                    "x": 1.01,
+                    "y": -0.18,
+                    "sizex": 0.10,
+                    "sizey": 0.10,
+                    "xanchor": "right",
+                    "yanchor": "bottom",
+                }
+            ]
         }
     return {}
+
 
 def main():
     # Header with PolicyEngine branding
@@ -123,14 +133,17 @@ def main():
         unsafe_allow_html=True,
     )
 
-    st.markdown("""
+    st.markdown(
+        """
     The Inflation Reduction Act enhanced ACA subsidies through 2025. Use this calculator to explore how extending these enhancements to 2026 would affect your household's premium tax credits.
 
     📖 [Learn more about enhanced premium tax credits](https://policyengine.org/us/research/enhanced-premium-tax-credits-extension)
-    """)
+    """
+    )
 
     with st.expander("Understanding the enhanced subsidies"):
-        st.markdown("""
+        st.markdown(
+            """
         **Enhanced PTCs extended:**
         - No income cap - households above 400% FPL can still receive credits
         - Lower premium contribution percentages (0-8.5% of income)
@@ -140,8 +153,9 @@ def main():
         - Hard cap at 400% FPL - no credits above this level (the "subsidy cliff")
         - Higher contribution percentages (2-9.5% of income)
         - Less generous subsidies, especially for middle incomes
-        """)
-    
+        """
+        )
+
     counties = load_counties()
 
     # Sidebar for household configuration
@@ -156,7 +170,10 @@ def main():
 
         if married:
             age_spouse = st.number_input(
-                "How old is your spouse?", min_value=18, max_value=100, value=35
+                "How old is your spouse?",
+                min_value=18,
+                max_value=100,
+                value=35,
             )
         else:
             age_spouse = None
@@ -165,7 +182,7 @@ def main():
             "How many children or dependents do you have?",
             min_value=0,
             max_value=10,
-            value=0
+            value=0,
         )
         dependent_ages = []
 
@@ -177,7 +194,7 @@ def main():
                     min_value=0,
                     max_value=25,
                     value=10,
-                    key=f"dep_{i}"
+                    key=f"dep_{i}",
                 )
                 dependent_ages.append(age_dep)
 
@@ -187,17 +204,66 @@ def main():
             value=0,
             step=1000,
             help="Modified Adjusted Gross Income (MAGI) as defined in 26 USC § 36B(d)(2). Includes: wages, self-employment income, capital gains, interest, dividends, pensions, Social Security, unemployment, rental income, and other income sources. Also includes tax-exempt interest and tax-exempt Social Security.",
-            format="%d"
+            format="%d",
         )
 
-        states = ["AL", "AK", "AZ", "AR", "CA", "CO", "CT", "DE", "FL",
-                  "GA", "HI", "ID", "IL", "IN", "IA", "KS", "KY", "LA",
-                  "ME", "MD", "MA", "MI", "MN", "MS", "MO", "MT", "NE",
-                  "NV", "NH", "NJ", "NM", "NY", "NC", "ND", "OH", "OK",
-                  "OR", "PA", "RI", "SC", "SD", "TN", "TX", "UT", "VT",
-                  "VA", "WA", "WV", "WI", "WY", "DC"]
+        states = [
+            "AL",
+            "AK",
+            "AZ",
+            "AR",
+            "CA",
+            "CO",
+            "CT",
+            "DE",
+            "FL",
+            "GA",
+            "HI",
+            "ID",
+            "IL",
+            "IN",
+            "IA",
+            "KS",
+            "KY",
+            "LA",
+            "ME",
+            "MD",
+            "MA",
+            "MI",
+            "MN",
+            "MS",
+            "MO",
+            "MT",
+            "NE",
+            "NV",
+            "NH",
+            "NJ",
+            "NM",
+            "NY",
+            "NC",
+            "ND",
+            "OH",
+            "OK",
+            "OR",
+            "PA",
+            "RI",
+            "SC",
+            "SD",
+            "TN",
+            "TX",
+            "UT",
+            "VT",
+            "VA",
+            "WA",
+            "WV",
+            "WI",
+            "WY",
+            "DC",
+        ]
 
-        state = st.selectbox("Which state do you live in?", states, index=0)  # Default to AL
+        state = st.selectbox(
+            "Which state do you live in?", states, index=0
+        )  # Default to AL
 
         # County selection - auto-select first alphabetically
         county = None
@@ -207,31 +273,45 @@ def main():
                 "Which county?",
                 sorted_counties,
                 index=0,
-                help="County used for marketplace calculations"
+                help="County used for marketplace calculations",
             )
+
+        # ZIP code input - required for LA County
+        zip_code = None
+        if state == "CA" and county == "Los Angeles County":
+            zip_code = st.text_input(
+                "What is your ZIP code?",
+                max_chars=5,
+                help="Los Angeles County has multiple rating areas. ZIP code is required for accurate premium calculations.",
+                placeholder="90001",
+            )
+            if zip_code and (len(zip_code) != 5 or not zip_code.isdigit()):
+                st.error("Please enter a valid 5-digit ZIP code")
+                zip_code = None
 
         st.markdown("---")
 
         calculate_button = st.button(
             "Calculate Premium Tax Credits",
             type="primary",
-            use_container_width=True
+            use_container_width=True,
         )
 
         if calculate_button:
             st.session_state.calculate = True
             st.session_state.params = {
-                'age_head': age_head,
-                'age_spouse': age_spouse,
-                'income': income,
-                'dependent_ages': dependent_ages,
-                'state': state,
-                'county': county,
-                'married': married
+                "age_head": age_head,
+                "age_spouse": age_spouse,
+                "income": income,
+                "dependent_ages": dependent_ages,
+                "state": state,
+                "county": county,
+                "married": married,
+                "zip_code": zip_code,
             }
 
     # Main content area
-    if hasattr(st.session_state, 'calculate') and st.session_state.calculate:
+    if hasattr(st.session_state, "calculate") and st.session_state.calculate:
         st.header("Your Results")
 
         params = st.session_state.params
@@ -239,26 +319,43 @@ def main():
         with st.spinner("Calculating..."):
             # Calculate PTCs - compare 2026 baseline vs 2026 with IRA reform!
             # Pass county name if selected (will be converted to PolicyEngine format)
-            county_name = params['county'] if params['county'] else None
+            county_name = params["county"] if params["county"] else None
+
+            zip_code = params.get("zip_code")
 
             ptc_2026_with_ira, slcsp_2026, fpl, fpl_pct = calculate_ptc(
-                params['age_head'], params['age_spouse'], params['income'],
-                params['dependent_ages'], params['state'], county_name, use_reform=True
+                params["age_head"],
+                params["age_spouse"],
+                params["income"],
+                params["dependent_ages"],
+                params["state"],
+                county_name,
+                zip_code=zip_code,
+                use_reform=True,
             )
 
             ptc_2026_baseline, _, _, _ = calculate_ptc(
-                params['age_head'], params['age_spouse'], params['income'],
-                params['dependent_ages'], params['state'], county_name, use_reform=False
+                params["age_head"],
+                params["age_spouse"],
+                params["income"],
+                params["dependent_ages"],
+                params["state"],
+                county_name,
+                zip_code=zip_code,
+                use_reform=False,
             )
 
             difference = ptc_2026_with_ira - ptc_2026_baseline
 
             # Display SLCSP if available
             if slcsp_2026 > 0:
-                st.info(f"Your base Second Lowest Cost Silver Plan is ${slcsp_2026:,.0f} per year (${slcsp_2026/12:,.0f} per month)")
+                st.info(
+                    f"Your base Second Lowest Cost Silver Plan is ${slcsp_2026:,.0f} per year (${slcsp_2026/12:,.0f} per month)"
+                )
 
             # Display metrics with custom CSS to prevent truncation
-            st.markdown("""
+            st.markdown(
+                """
             <style>
             [data-testid="stMetricValue"] {
                 font-size: 1.4rem !important;
@@ -271,62 +368,113 @@ def main():
                 line-height: 1.2 !important;
             }
             </style>
-            """, unsafe_allow_html=True)
+            """,
+                unsafe_allow_html=True,
+            )
 
             col_baseline, col_with_ira, col_diff = st.columns(3)
 
             with col_baseline:
-                st.metric("Current law", f"${ptc_2026_baseline:,.0f} per year",
-                         help="Your credits under current law (enhanced PTCs expire)")
+                st.metric(
+                    "Current law",
+                    f"${ptc_2026_baseline:,.0f} per year",
+                    help="Your credits under current law (enhanced PTCs expire)",
+                )
 
             with col_with_ira:
-                st.metric("Enhanced PTCs extended", f"${ptc_2026_with_ira:,.0f} per year",
-                         help="Your credits if enhanced subsidies were extended")
+                st.metric(
+                    "Enhanced PTCs extended",
+                    f"${ptc_2026_with_ira:,.0f} per year",
+                    help="Your credits if enhanced subsidies were extended",
+                )
 
             with col_diff:
                 if difference > 0:
-                    st.metric("You Lose", f"${difference:,.0f} per year",
-                             f"-${difference/12:,.0f} per month", delta_color="inverse")
+                    st.metric(
+                        "You Lose",
+                        f"${difference:,.0f} per year",
+                        f"-${difference/12:,.0f} per month",
+                        delta_color="inverse",
+                    )
                 elif difference < 0:
                     # This shouldn't happen but just in case
-                    st.metric("You Gain?", f"${abs(difference):,.0f} per year",
-                             f"+${abs(difference)/12:,.0f} per month", delta_color="normal")
+                    st.metric(
+                        "You Gain?",
+                        f"${abs(difference):,.0f} per year",
+                        f"+${abs(difference)/12:,.0f} per month",
+                        delta_color="normal",
+                    )
                 else:
                     st.metric("No Change", "$0")
 
             # Impact message
             if ptc_2026_with_ira == 0 and ptc_2026_baseline == 0:
                 st.info("### No Premium Tax Credits Available")
-                st.write("You don't qualify for premium tax credits in either scenario. Check the chart below to see potential Medicaid or CHIP eligibility.")
+                st.write(
+                    "You don't qualify for premium tax credits in either scenario. Check the chart below to see potential Medicaid or CHIP eligibility."
+                )
             elif ptc_2026_with_ira > 0 and ptc_2026_baseline == 0:
-                st.warning("### Credits available only with enhanced PTCs extended")
-                st.warning(f"Premium tax credits: ${ptc_2026_with_ira:,.0f} per year with enhanced PTCs extended, $0 under current law.")
-                st.warning("Under current law (without enhanced PTCs), you would not qualify for credits. Enhanced PTCs remove the income cap and lower contribution percentages.")
+                st.warning(
+                    "### Credits available only with enhanced PTCs extended"
+                )
+                st.warning(
+                    f"Premium tax credits: ${ptc_2026_with_ira:,.0f} per year with enhanced PTCs extended, $0 under current law."
+                )
+                st.warning(
+                    "Under current law (without enhanced PTCs), you would not qualify for credits. Enhanced PTCs remove the income cap and lower contribution percentages."
+                )
             elif difference > 0:
                 st.info("### Credit reduction under current law")
-                st.info(f"Premium tax credits decrease by ${difference:,.0f} per year (${difference/12:,.0f} per month) when enhanced PTCs expire.")
+                st.info(
+                    f"Premium tax credits decrease by ${difference:,.0f} per year (${difference/12:,.0f} per month) when enhanced PTCs expire."
+                )
             else:
                 st.success("### No Change in Credits")
 
             # Optional Chart - only generate when requested
             st.markdown("---")
-            if st.button("📊 Show income comparison chart", help="Generate interactive charts showing how credits change across income levels"):
+            if st.button(
+                "📊 Show income comparison chart",
+                help="Generate interactive charts showing how credits change across income levels",
+            ):
                 with st.spinner("Generating charts..."):
-                    fig_comparison, fig_delta = create_chart(ptc_2026_with_ira, ptc_2026_baseline, params['age_head'], params['age_spouse'],
-                                     tuple(params['dependent_ages']), params['state'], params['income'], params['county'])
+                    fig_comparison, fig_delta = create_chart(
+                        ptc_2026_with_ira,
+                        ptc_2026_baseline,
+                        params["age_head"],
+                        params["age_spouse"],
+                        tuple(params["dependent_ages"]),
+                        params["state"],
+                        params["income"],
+                        params["county"],
+                        params.get("zip_code"),
+                    )
 
                     tab1, tab2 = st.tabs(["Comparison", "Difference"])
 
                     with tab1:
-                        st.plotly_chart(fig_comparison, use_container_width=True, config={'displayModeBar': False})
+                        st.plotly_chart(
+                            fig_comparison,
+                            use_container_width=True,
+                            config={"displayModeBar": False},
+                        )
 
                     with tab2:
-                        st.plotly_chart(fig_delta, use_container_width=True, config={'displayModeBar': False})
+                        st.plotly_chart(
+                            fig_delta,
+                            use_container_width=True,
+                            config={"displayModeBar": False},
+                        )
 
             # Details
             with st.expander("See calculation details"):
-                household_size = 1 + (1 if params['age_spouse'] else 0) + len(params['dependent_ages'])
-                st.write(f"""
+                household_size = (
+                    1
+                    + (1 if params["age_spouse"] else 0)
+                    + len(params["dependent_ages"])
+                )
+                st.write(
+                    f"""
                 ### Your Household
                 - **Size:** {household_size} people
                 - **Income:** ${params['income']:,} ({fpl_pct:.0f}% of FPL)
@@ -344,9 +492,20 @@ def main():
                 - No credits at all above 400% FPL without IRA extension
 
                 If the benchmark plan costs less than your required contribution, you get no credit.
-                """)
+                """
+                )
 
-def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_name=None, use_reform=False):
+
+def calculate_ptc(
+    age_head,
+    age_spouse,
+    income,
+    dependent_ages,
+    state,
+    county_name=None,
+    zip_code=None,
+    use_reform=False,
+):
     """Calculate PTC for baseline or IRA enhanced scenario using 2026 comparison
 
     Matches notebook pattern exactly - uses copy.deepcopy pattern with income injection
@@ -354,42 +513,62 @@ def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_na
     Args:
         county_name: County name from dropdown (e.g. "Travis County")
                     Will be converted to PolicyEngine format (TRAVIS_COUNTY_TX)
+        zip_code: 5-digit ZIP code string (required for LA County)
 
     Returns:
         tuple: (ptc, slcsp, fpl, fpl_pct) - PTC amount, SLCSP premium, FPL dollar amount, and income as % of FPL (for display only)
     """
     import copy
+
     try:
         # Build base household situation (matches notebook structure exactly)
         situation = {
-            "people": {
-                "you": {"age": {2026: age_head}}
-            },
+            "people": {"you": {"age": {2026: age_head}}},
             "families": {"your family": {"members": ["you"]}},
             "spm_units": {"your household": {"members": ["you"]}},
             "tax_units": {"your tax unit": {"members": ["you"]}},
             "households": {
                 "your household": {
                     "members": ["you"],
-                    "state_name": {2026: state}
+                    "state_name": {2026: state},
                 }
-            }
+            },
         }
 
         # Add county if provided - convert to PolicyEngine format
         if county_name:
             # Convert "Travis County" -> "TRAVIS_COUNTY_TX"
-            county_pe_format = county_name.upper().replace(' ', '_') + '_' + state
-            situation["households"]["your household"]["county"] = {2026: county_pe_format}
+            county_pe_format = (
+                county_name.upper().replace(" ", "_") + "_" + state
+            )
+            situation["households"]["your household"]["county"] = {
+                2026: county_pe_format
+            }
+
+        # Add ZIP code if provided (required for LA County)
+        if zip_code:
+            situation["households"]["your household"]["zip_code"] = {
+                2026: zip_code
+            }
 
         # Add spouse if married
         if age_spouse:
             situation["people"]["your partner"] = {"age": {2026: age_spouse}}
-            situation["families"]["your family"]["members"].append("your partner")
-            situation["spm_units"]["your household"]["members"].append("your partner")
-            situation["tax_units"]["your tax unit"]["members"].append("your partner")
-            situation["households"]["your household"]["members"].append("your partner")
-            situation["marital_units"] = {"your marital unit": {"members": ["you", "your partner"]}}
+            situation["families"]["your family"]["members"].append(
+                "your partner"
+            )
+            situation["spm_units"]["your household"]["members"].append(
+                "your partner"
+            )
+            situation["tax_units"]["your tax unit"]["members"].append(
+                "your partner"
+            )
+            situation["households"]["your household"]["members"].append(
+                "your partner"
+            )
+            situation["marital_units"] = {
+                "your marital unit": {"members": ["you", "your partner"]}
+            }
 
         # Add dependents with consistent naming (matches notebook)
         for i, dep_age in enumerate(dependent_ages):
@@ -402,9 +581,13 @@ def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_na
 
             situation["people"][child_id] = {"age": {2026: dep_age}}
             situation["families"]["your family"]["members"].append(child_id)
-            situation["spm_units"]["your household"]["members"].append(child_id)
+            situation["spm_units"]["your household"]["members"].append(
+                child_id
+            )
             situation["tax_units"]["your tax unit"]["members"].append(child_id)
-            situation["households"]["your household"]["members"].append(child_id)
+            situation["households"]["your household"]["members"].append(
+                child_id
+            )
 
             # Add child's marital unit
             if "marital_units" not in situation:
@@ -420,7 +603,9 @@ def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_na
         # Note: Cannot set aca_magi directly - must use employment_income for reforms to work
         if age_spouse:
             sit["people"]["you"]["employment_income"] = {2026: income / 2}
-            sit["people"]["your partner"]["employment_income"] = {2026: income / 2}
+            sit["people"]["your partner"]["employment_income"] = {
+                2026: income / 2
+            }
         else:
             sit["people"]["you"]["employment_income"] = {2026: income}
 
@@ -428,16 +613,36 @@ def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_na
         reform = None
         if use_reform:
             from policyengine_core.reforms import Reform
-            reform = Reform.from_dict({
-                "gov.aca.ptc_phase_out_rate[0].amount": {"2026-01-01.2100-12-31": 0},
-                "gov.aca.ptc_phase_out_rate[1].amount": {"2025-01-01.2100-12-31": 0},
-                "gov.aca.ptc_phase_out_rate[2].amount": {"2026-01-01.2100-12-31": 0},
-                "gov.aca.ptc_phase_out_rate[3].amount": {"2026-01-01.2100-12-31": 0.02},
-                "gov.aca.ptc_phase_out_rate[4].amount": {"2026-01-01.2100-12-31": 0.04},
-                "gov.aca.ptc_phase_out_rate[5].amount": {"2026-01-01.2100-12-31": 0.06},
-                "gov.aca.ptc_phase_out_rate[6].amount": {"2026-01-01.2100-12-31": 0.085},
-                "gov.aca.ptc_income_eligibility[2].amount": {"2026-01-01.2100-12-31": True}
-            }, country_id="us")
+
+            reform = Reform.from_dict(
+                {
+                    "gov.aca.ptc_phase_out_rate[0].amount": {
+                        "2026-01-01.2100-12-31": 0
+                    },
+                    "gov.aca.ptc_phase_out_rate[1].amount": {
+                        "2025-01-01.2100-12-31": 0
+                    },
+                    "gov.aca.ptc_phase_out_rate[2].amount": {
+                        "2026-01-01.2100-12-31": 0
+                    },
+                    "gov.aca.ptc_phase_out_rate[3].amount": {
+                        "2026-01-01.2100-12-31": 0.02
+                    },
+                    "gov.aca.ptc_phase_out_rate[4].amount": {
+                        "2026-01-01.2100-12-31": 0.04
+                    },
+                    "gov.aca.ptc_phase_out_rate[5].amount": {
+                        "2026-01-01.2100-12-31": 0.06
+                    },
+                    "gov.aca.ptc_phase_out_rate[6].amount": {
+                        "2026-01-01.2100-12-31": 0.085
+                    },
+                    "gov.aca.ptc_income_eligibility[2].amount": {
+                        "2026-01-01.2100-12-31": True
+                    },
+                },
+                country_id="us",
+            )
 
         # Run simulation
         sim = Simulation(situation=sit, reform=reform)
@@ -454,11 +659,26 @@ def calculate_ptc(age_head, age_spouse, income, dependent_ages, state, county_na
     except Exception as e:
         st.error(f"Calculation error: {str(e)}")
         import traceback
+
         st.error(traceback.format_exc())
         return 0, 0, 0, 0
 
-def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_ages, state, income, county=None):
+
+def create_chart(
+    ptc_with_ira,
+    ptc_baseline,
+    age_head,
+    age_spouse,
+    dependent_ages,
+    state,
+    income,
+    county=None,
+    zip_code=None,
+):
     """Create income curve charts showing PTC across income range with user's position marked
+
+    Args:
+        zip_code: 5-digit ZIP code string (required for LA County)
 
     Returns tuple of (comparison_fig, delta_fig)
 
@@ -467,17 +687,12 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
 
     # Create base household structure for income sweep
     base_household = {
-        "people": {
-            "you": {"age": {2026: age_head}}
-        },
+        "people": {"you": {"age": {2026: age_head}}},
         "families": {"your family": {"members": ["you"]}},
         "spm_units": {"your household": {"members": ["you"]}},
         "tax_units": {"your tax unit": {"members": ["you"]}},
         "households": {
-            "your household": {
-                "members": ["you"],
-                "state_name": {2026: state}
-            }
+            "your household": {"members": ["you"], "state_name": {2026: state}}
         },
         "axes": [
             [
@@ -486,25 +701,43 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
                     "count": 1001,  # 1001 points for exact 1k increments (0 to 1M)
                     "min": 0,
                     "max": 1000000,
-                    "period": 2026  # Specify period to get exact values without uprating
+                    "period": 2026,  # Specify period to get exact values without uprating
                 }
             ]
-        ]
+        ],
     }
-    
+
     # Add county if provided
     if county:
-        county_pe_format = county.upper().replace(' ', '_') + '_' + state
-        base_household["households"]["your household"]["county"] = {2026: county_pe_format}
+        county_pe_format = county.upper().replace(" ", "_") + "_" + state
+        base_household["households"]["your household"]["county"] = {
+            2026: county_pe_format
+        }
+
+    # Add ZIP code if provided (required for LA County)
+    if zip_code:
+        base_household["households"]["your household"]["zip_code"] = {
+            2026: zip_code
+        }
 
     # Add spouse if married
     if age_spouse:
         base_household["people"]["your partner"] = {"age": {2026: age_spouse}}
-        base_household["families"]["your family"]["members"].append("your partner")
-        base_household["spm_units"]["your household"]["members"].append("your partner")
-        base_household["tax_units"]["your tax unit"]["members"].append("your partner")
-        base_household["households"]["your household"]["members"].append("your partner")
-        base_household["marital_units"] = {"your marital unit": {"members": ["you", "your partner"]}}
+        base_household["families"]["your family"]["members"].append(
+            "your partner"
+        )
+        base_household["spm_units"]["your household"]["members"].append(
+            "your partner"
+        )
+        base_household["tax_units"]["your tax unit"]["members"].append(
+            "your partner"
+        )
+        base_household["households"]["your household"]["members"].append(
+            "your partner"
+        )
+        base_household["marital_units"] = {
+            "your marital unit": {"members": ["you", "your partner"]}
+        }
 
     # Add dependents
     for i, dep_age in enumerate(dependent_ages):
@@ -517,9 +750,15 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
 
         base_household["people"][child_id] = {"age": {2026: dep_age}}
         base_household["families"]["your family"]["members"].append(child_id)
-        base_household["spm_units"]["your household"]["members"].append(child_id)
-        base_household["tax_units"]["your tax unit"]["members"].append(child_id)
-        base_household["households"]["your household"]["members"].append(child_id)
+        base_household["spm_units"]["your household"]["members"].append(
+            child_id
+        )
+        base_household["tax_units"]["your tax unit"]["members"].append(
+            child_id
+        )
+        base_household["households"]["your household"]["members"].append(
+            child_id
+        )
 
         # Add child's marital unit
         if "marital_units" not in base_household:
@@ -531,28 +770,58 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
     try:
         # Create reform for chart calculation
         from policyengine_core.reforms import Reform
-        reform = Reform.from_dict({
-            "gov.aca.ptc_phase_out_rate[0].amount": {"2026-01-01.2100-12-31": 0},
-            "gov.aca.ptc_phase_out_rate[1].amount": {"2025-01-01.2100-12-31": 0},
-            "gov.aca.ptc_phase_out_rate[2].amount": {"2026-01-01.2100-12-31": 0},
-            "gov.aca.ptc_phase_out_rate[3].amount": {"2026-01-01.2100-12-31": 0.02},
-            "gov.aca.ptc_phase_out_rate[4].amount": {"2026-01-01.2100-12-31": 0.04},
-            "gov.aca.ptc_phase_out_rate[5].amount": {"2026-01-01.2100-12-31": 0.06},
-            "gov.aca.ptc_phase_out_rate[6].amount": {"2026-01-01.2100-12-31": 0.085},
-            "gov.aca.ptc_income_eligibility[2].amount": {"2026-01-01.2100-12-31": True}
-        }, country_id="us")
-        
+
+        reform = Reform.from_dict(
+            {
+                "gov.aca.ptc_phase_out_rate[0].amount": {
+                    "2026-01-01.2100-12-31": 0
+                },
+                "gov.aca.ptc_phase_out_rate[1].amount": {
+                    "2025-01-01.2100-12-31": 0
+                },
+                "gov.aca.ptc_phase_out_rate[2].amount": {
+                    "2026-01-01.2100-12-31": 0
+                },
+                "gov.aca.ptc_phase_out_rate[3].amount": {
+                    "2026-01-01.2100-12-31": 0.02
+                },
+                "gov.aca.ptc_phase_out_rate[4].amount": {
+                    "2026-01-01.2100-12-31": 0.04
+                },
+                "gov.aca.ptc_phase_out_rate[5].amount": {
+                    "2026-01-01.2100-12-31": 0.06
+                },
+                "gov.aca.ptc_phase_out_rate[6].amount": {
+                    "2026-01-01.2100-12-31": 0.085
+                },
+                "gov.aca.ptc_income_eligibility[2].amount": {
+                    "2026-01-01.2100-12-31": True
+                },
+            },
+            country_id="us",
+        )
+
         # Calculate both curves - baseline and reform for 2026
         sim_baseline = Simulation(situation=base_household)
         sim_reform = Simulation(situation=base_household, reform=reform)
 
-        income_range = sim_baseline.calculate("employment_income", map_to="household", period=2026)
-        ptc_range_baseline = sim_baseline.calculate("aca_ptc", map_to="household", period=2026)
-        ptc_range_reform = sim_reform.calculate("aca_ptc", map_to="household", period=2026)
+        income_range = sim_baseline.calculate(
+            "employment_income", map_to="household", period=2026
+        )
+        ptc_range_baseline = sim_baseline.calculate(
+            "aca_ptc", map_to="household", period=2026
+        )
+        ptc_range_reform = sim_reform.calculate(
+            "aca_ptc", map_to="household", period=2026
+        )
 
         # Calculate Medicaid and CHIP values
-        medicaid_range = sim_baseline.calculate("medicaid_cost", map_to="household", period=2026)
-        chip_range = sim_baseline.calculate("per_capita_chip", map_to="household", period=2026)
+        medicaid_range = sim_baseline.calculate(
+            "medicaid_cost", map_to="household", period=2026
+        )
+        chip_range = sim_baseline.calculate(
+            "per_capita_chip", map_to="household", period=2026
+        )
 
         # Find where PTC goes to zero for dynamic x-axis range
         # Use reform PTC since it always extends to higher incomes than baseline
@@ -571,6 +840,7 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
 
         # Create hover text based on program eligibility
         import numpy as np
+
         hover_text = []
         for i in range(len(income_range)):
             inc = income_range[i]
@@ -582,21 +852,22 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
 
             text = f"<b>Income: ${inc:,.0f}</b><br><br>"
 
-            # Check if eligible for Medicaid or CHIP
+            # Show all applicable benefits (not mutually exclusive)
             if medicaid > 0:
-                text += f"<b>Medicaid eligible</b><br>Estimated value: ${medicaid:,.0f}/year<br>"
-            elif chip > 0:
-                text += f"<b>CHIP eligible</b><br>Estimated value: ${chip:,.0f}/year<br>"
-            else:
-                # Show PTC information
+                text += f"<b>Medicaid:</b> ${medicaid:,.0f}/year<br>"
+            if chip > 0:
+                text += f"<b>CHIP:</b> ${chip:,.0f}/year<br>"
+
+            # Always show PTC information if present
+            if ptc_base > 0 or ptc_ref > 0:
                 text += f"<b>PTC (current law):</b> ${ptc_base:,.0f}/year<br>"
                 text += f"<b>PTC (extended):</b> ${ptc_ref:,.0f}/year<br>"
                 if delta > 0:
-                    text += f"<b>Difference:</b> +${delta:,.0f}/year"
+                    text += f"<b>PTC difference:</b> +${delta:,.0f}/year"
                 elif delta < 0:
-                    text += f"<b>Difference:</b> -${abs(delta):,.0f}/year"
+                    text += f"<b>PTC difference:</b> -${abs(delta):,.0f}/year"
                 else:
-                    text += f"<b>Difference:</b> $0"
+                    text += f"<b>PTC difference:</b> $0"
 
             hover_text.append(text)
 
@@ -604,74 +875,95 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
         fig = go.Figure()
 
         # Add invisible hover trace with unified information
-        fig.add_trace(go.Scatter(
-            x=income_range,
-            y=np.maximum.reduce([medicaid_range, chip_range, ptc_range_baseline, ptc_range_reform]),
-            mode='lines',
-            line=dict(width=0),
-            hovertext=hover_text,
-            hoverinfo='text',
-            showlegend=False,
-            name=''
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=income_range,
+                y=np.maximum.reduce(
+                    [
+                        medicaid_range,
+                        chip_range,
+                        ptc_range_baseline,
+                        ptc_range_reform,
+                    ]
+                ),
+                mode="lines",
+                line=dict(width=0),
+                hovertext=hover_text,
+                hoverinfo="text",
+                showlegend=False,
+                name="",
+            )
+        )
 
-        # Add Medicaid line
-        fig.add_trace(go.Scatter(
-            x=income_range,
-            y=medicaid_range,
-            mode='lines',
-            name='Medicaid',
-            line=dict(color=COLORS['green'], width=3),
-            hoverinfo='skip',
-            visible=True
-        ))
+        # Add Medicaid line only if any household member is eligible
+        if np.any(medicaid_range > 0):
+            fig.add_trace(
+                go.Scatter(
+                    x=income_range,
+                    y=medicaid_range,
+                    mode="lines",
+                    name="Medicaid",
+                    line=dict(color=COLORS["green"], width=3),
+                    hoverinfo="skip",
+                    visible=True,
+                )
+            )
 
-        # Add Children's Health Insurance Program (CHIP) line
-        fig.add_trace(go.Scatter(
-            x=income_range,
-            y=chip_range,
-            mode='lines',
-            name="Children's Health Insurance Program (CHIP)",
-            line=dict(color=COLORS['secondary'], width=3),
-            hoverinfo='skip',
-            visible=True
-        ))
+        # Add CHIP line only if any household member is eligible
+        if np.any(chip_range > 0):
+            fig.add_trace(
+                go.Scatter(
+                    x=income_range,
+                    y=chip_range,
+                    mode="lines",
+                    name="Children's Health Insurance Program (CHIP)",
+                    line=dict(color=COLORS["secondary"], width=3),
+                    hoverinfo="skip",
+                    visible=True,
+                )
+            )
 
         # Add baseline line (current law) - show first in legend
-        fig.add_trace(go.Scatter(
-            x=income_range,
-            y=ptc_range_baseline,
-            mode='lines',
-            name='PTC (current law)',
-            line=dict(color=COLORS['gray'], width=3),
-            hoverinfo='skip'
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=income_range,
+                y=ptc_range_baseline,
+                mode="lines",
+                name="PTC (current law)",
+                line=dict(color=COLORS["gray"], width=3),
+                hoverinfo="skip",
+            )
+        )
 
         # Add reform line (enhanced PTCs extended)
-        fig.add_trace(go.Scatter(
-            x=income_range,
-            y=ptc_range_reform,
-            mode='lines',
-            name='PTC (enhanced PTCs extended)',
-            line=dict(color=COLORS['primary'], width=3),
-            hoverinfo='skip'
-        ))
-        
+        fig.add_trace(
+            go.Scatter(
+                x=income_range,
+                y=ptc_range_reform,
+                mode="lines",
+                name="PTC (enhanced PTCs extended)",
+                line=dict(color=COLORS["primary"], width=3),
+                hoverinfo="skip",
+            )
+        )
+
         # Add user's position markers
-        fig.add_trace(go.Scatter(
-            x=[income, income],
-            y=[ptc_baseline, ptc_with_ira],
-            mode='markers',
-            name='Your Household',
-            marker=dict(
-                color=[COLORS['gray'], COLORS['primary']],
-                size=12,
-                symbol='diamond',
-                line=dict(width=2, color='white')
-            ),
-            hoverinfo='skip',
-            showlegend=False
-        ))
+        fig.add_trace(
+            go.Scatter(
+                x=[income, income],
+                y=[ptc_baseline, ptc_with_ira],
+                mode="markers",
+                name="Your Household",
+                marker=dict(
+                    color=[COLORS["gray"], COLORS["primary"]],
+                    size=12,
+                    symbol="diamond",
+                    line=dict(width=2, color="white"),
+                ),
+                hoverinfo="skip",
+                showlegend=False,
+            )
+        )
 
         # Add annotations for user's points (only if income > 0 to avoid cramping y-axis)
         if income > 10000:
@@ -683,12 +975,12 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
                 arrowhead=2,
                 arrowsize=1,
                 arrowwidth=2,
-                arrowcolor=COLORS['gray'],
+                arrowcolor=COLORS["gray"],
                 ax=60,
                 ay=40,
-                bgcolor='white',
-                bordercolor=COLORS['gray'],
-                borderwidth=2
+                bgcolor="white",
+                bordercolor=COLORS["gray"],
+                borderwidth=2,
             )
 
             fig.add_annotation(
@@ -699,14 +991,14 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
                 arrowhead=2,
                 arrowsize=1,
                 arrowwidth=2,
-                arrowcolor=COLORS['primary'],
+                arrowcolor=COLORS["primary"],
                 ax=60,
                 ay=-40,
-                bgcolor='white',
-                bordercolor=COLORS['primary'],
-                borderwidth=2
+                bgcolor="white",
+                bordercolor=COLORS["primary"],
+                borderwidth=2,
             )
-        
+
         # Update layout for comparison chart
         fig.update_layout(
             title={
@@ -716,20 +1008,20 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
             xaxis_title="Annual household income",
             yaxis_title="Annual healthcare assistance value",
             height=500,
-            xaxis=dict(tickformat='$,.0f', range=[0, x_axis_max], automargin=True),
-            yaxis=dict(tickformat='$,.0f', rangemode='tozero', automargin=True),
-            plot_bgcolor='white',
-            paper_bgcolor='white',
-            font=dict(family='Roboto, sans-serif'),
+            xaxis=dict(
+                tickformat="$,.0f", range=[0, x_axis_max], automargin=True
+            ),
+            yaxis=dict(
+                tickformat="$,.0f", rangemode="tozero", automargin=True
+            ),
+            plot_bgcolor="white",
+            paper_bgcolor="white",
+            font=dict(family="Roboto, sans-serif"),
             legend=dict(
-                orientation="h",
-                yanchor="bottom",
-                y=0.98,
-                xanchor="right",
-                x=1
+                orientation="h", yanchor="bottom", y=0.98, xanchor="right", x=1
             ),
             margin=dict(l=80, r=40, t=60, b=80),
-            **add_logo_to_layout()
+            **add_logo_to_layout(),
         )
 
         # Create delta chart
@@ -747,51 +1039,57 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
 
             text = f"<b>Income: ${inc:,.0f}</b><br><br>"
 
-            # Check if eligible for Medicaid or CHIP
+            # Show all applicable benefits
             if medicaid > 0:
-                text += f"<b>Medicaid eligible</b><br>Premium tax credits not applicable"
-            elif chip > 0:
-                text += f"<b>CHIP eligible</b><br>Premium tax credits not applicable"
-            else:
-                # Show gain from extension
-                if delta > 0:
-                    text += f"<b>Gain from extension:</b> ${delta:,.0f}/year"
-                elif delta < 0:
-                    text += f"<b>Loss from extension:</b> -${abs(delta):,.0f}/year"
-                else:
-                    text += f"<b>No change</b>"
+                text += f"<b>Medicaid:</b> ${medicaid:,.0f}/year<br>"
+            if chip > 0:
+                text += f"<b>CHIP:</b> ${chip:,.0f}/year<br>"
+
+            # Show PTC gain/loss from extension
+            if delta > 0:
+                text += f"<b>PTC gain from extension:</b> ${delta:,.0f}/year"
+            elif delta < 0:
+                text += (
+                    f"<b>PTC loss from extension:</b> -${abs(delta):,.0f}/year"
+                )
+            elif ptc_range_baseline[i] > 0 or ptc_range_reform[i] > 0:
+                text += f"<b>PTC: no change</b>"
 
             delta_hover_text.append(text)
 
         # Add delta line
-        fig_delta.add_trace(go.Scatter(
-            x=income_range,
-            y=delta_range,
-            mode='lines',
-            name='PTC gain from extension',
-            line=dict(color=COLORS['primary'], width=3),
-            fill='tozeroy',
-            fillcolor=f"rgba(44, 100, 150, 0.2)",
-            hovertext=delta_hover_text,
-            hoverinfo='text'
-        ))
+        fig_delta.add_trace(
+            go.Scatter(
+                x=income_range,
+                y=delta_range,
+                mode="lines",
+                name="PTC gain from extension",
+                line=dict(color=COLORS["primary"], width=3),
+                fill="tozeroy",
+                fillcolor=f"rgba(44, 100, 150, 0.2)",
+                hovertext=delta_hover_text,
+                hoverinfo="text",
+            )
+        )
 
         # Add user's position marker
         if income > 10000:
-            fig_delta.add_trace(go.Scatter(
-                x=[income],
-                y=[user_difference],
-                mode='markers',
-                name='Your household',
-                marker=dict(
-                    color=COLORS['primary'],
-                    size=12,
-                    symbol='diamond',
-                    line=dict(width=2, color='white')
-                ),
-                hoverinfo='skip',
-                showlegend=False
-            ))
+            fig_delta.add_trace(
+                go.Scatter(
+                    x=[income],
+                    y=[user_difference],
+                    mode="markers",
+                    name="Your household",
+                    marker=dict(
+                        color=COLORS["primary"],
+                        size=12,
+                        symbol="diamond",
+                        line=dict(width=2, color="white"),
+                    ),
+                    hoverinfo="skip",
+                    showlegend=False,
+                )
+            )
 
             fig_delta.add_annotation(
                 x=income,
@@ -801,12 +1099,12 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
                 arrowhead=2,
                 arrowsize=1,
                 arrowwidth=2,
-                arrowcolor=COLORS['primary'],
+                arrowcolor=COLORS["primary"],
                 ax=60,
                 ay=-40,
-                bgcolor='white',
-                bordercolor=COLORS['primary'],
-                borderwidth=2
+                bgcolor="white",
+                bordercolor=COLORS["primary"],
+                borderwidth=2,
             )
 
         fig_delta.update_layout(
@@ -817,66 +1115,75 @@ def create_chart(ptc_with_ira, ptc_baseline, age_head, age_spouse, dependent_age
             xaxis_title="Annual household income",
             yaxis_title="Annual PTC gain (extended - current law)",
             height=500,
-            xaxis=dict(tickformat='$,.0f', range=[0, x_axis_max], automargin=True),
-            yaxis=dict(tickformat='$,.0f', rangemode='tozero', automargin=True),
-            plot_bgcolor='white',
-            paper_bgcolor='white',
-            font=dict(family='Roboto, sans-serif'),
+            xaxis=dict(
+                tickformat="$,.0f", range=[0, x_axis_max], automargin=True
+            ),
+            yaxis=dict(
+                tickformat="$,.0f", rangemode="tozero", automargin=True
+            ),
+            plot_bgcolor="white",
+            paper_bgcolor="white",
+            font=dict(family="Roboto, sans-serif"),
             showlegend=False,
             margin=dict(l=80, r=40, t=60, b=80),
-            **add_logo_to_layout()
+            **add_logo_to_layout(),
         )
 
         return fig, fig_delta
-        
+
     except Exception as e:
         # Fallback to simple bar charts if curve fails
-        colors = [COLORS['gray'], COLORS['primary']]
+        colors = [COLORS["gray"], COLORS["primary"]]
 
         # Comparison bar chart
-        fig_comp = go.Figure(data=[
-            go.Bar(
-                x=['Current law', 'Enhanced PTCs<br>extended'],
-                y=[ptc_baseline, ptc_with_ira],
-                text=[f'${ptc_baseline:,.0f}', f'${ptc_with_ira:,.0f}'],
-                textposition='outside',
-                marker_color=colors
-            )
-        ])
+        fig_comp = go.Figure(
+            data=[
+                go.Bar(
+                    x=["Current law", "Enhanced PTCs<br>extended"],
+                    y=[ptc_baseline, ptc_with_ira],
+                    text=[f"${ptc_baseline:,.0f}", f"${ptc_with_ira:,.0f}"],
+                    textposition="outside",
+                    marker_color=colors,
+                )
+            ]
+        )
 
         fig_comp.update_layout(
             title="Annual premium tax credit comparison",
             yaxis_title="Credit amount ($)",
             height=400,
             showlegend=False,
-            yaxis=dict(rangemode='tozero'),
-            plot_bgcolor='white',
-            **add_logo_to_layout()
+            yaxis=dict(rangemode="tozero"),
+            plot_bgcolor="white",
+            **add_logo_to_layout(),
         )
 
         # Delta bar chart
         user_difference = ptc_with_ira - ptc_baseline
-        fig_delta = go.Figure(data=[
-            go.Bar(
-                x=['PTC gain from<br>extending enhanced subsidies'],
-                y=[user_difference],
-                text=[f'${user_difference:,.0f}'],
-                textposition='outside',
-                marker_color=COLORS['primary']
-            )
-        ])
+        fig_delta = go.Figure(
+            data=[
+                go.Bar(
+                    x=["PTC gain from<br>extending enhanced subsidies"],
+                    y=[user_difference],
+                    text=[f"${user_difference:,.0f}"],
+                    textposition="outside",
+                    marker_color=COLORS["primary"],
+                )
+            ]
+        )
 
         fig_delta.update_layout(
             title="PTC gain from extending enhanced subsidies",
             yaxis_title="Gain ($)",
             height=400,
             showlegend=False,
-            yaxis=dict(rangemode='tozero'),
-            plot_bgcolor='white',
-            **add_logo_to_layout()
+            yaxis=dict(rangemode="tozero"),
+            plot_bgcolor="white",
+            **add_logo_to_layout(),
         )
 
         return fig_comp, fig_delta
+
 
 if __name__ == "__main__":
     main()

--- a/app.py
+++ b/app.py
@@ -698,7 +698,7 @@ def create_chart(
             [
                 {
                     "name": "employment_income",
-                    "count": 1001,  # 1001 points for exact 1k increments (0 to 1M)
+                    "count": 10_001,  # 10_001 points for exact $100 increments (0 to 1M)
                     "min": 0,
                     "max": 1000000,
                     "period": 2026,  # Specify period to get exact values without uprating

--- a/tests/test_calculate_ptc.py
+++ b/tests/test_calculate_ptc.py
@@ -1,6 +1,8 @@
 """Test calculate_ptc function."""
+
 import sys
-sys.path.insert(0, '.')
+
+sys.path.insert(0, ".")
 
 from app import calculate_ptc
 
@@ -10,14 +12,14 @@ def test_simple_calculation():
     print("Testing simple single person calculation...")
 
     # Single person, age 35, $50,000 income in TX
-    ptc_reform, slcsp = calculate_ptc(
+    ptc_reform, slcsp, fpl, fpl_pct = calculate_ptc(
         age_head=35,
         age_spouse=None,
         income=50000,
         dependent_ages=[],
         state="TX",
         county_name=None,
-        use_reform=True
+        use_reform=True,
     )
 
     print(f"Reform PTC: ${ptc_reform:,.0f}")
@@ -35,24 +37,24 @@ def test_baseline_vs_reform():
     print("\nTesting baseline vs reform...")
 
     # Couple at 300% FPL
-    ptc_reform, slcsp = calculate_ptc(
+    ptc_reform, slcsp, fpl, fpl_pct = calculate_ptc(
         age_head=25,
         age_spouse=28,
         income=63450,
         dependent_ages=[],
         state="TX",
         county_name=None,
-        use_reform=True
+        use_reform=True,
     )
 
-    ptc_baseline, _ = calculate_ptc(
+    ptc_baseline, _, _, _ = calculate_ptc(
         age_head=25,
         age_spouse=28,
         income=63450,
         dependent_ages=[],
         state="TX",
         county_name=None,
-        use_reform=False
+        use_reform=False,
     )
 
     print(f"Reform PTC: ${ptc_reform:,.0f}")
@@ -61,7 +63,9 @@ def test_baseline_vs_reform():
 
     assert slcsp > 0, "SLCSP should be > 0"
     # Reform should give more credits than baseline at 300% FPL
-    assert ptc_reform >= ptc_baseline, f"Reform ({ptc_reform}) should be >= baseline ({ptc_baseline})"
+    assert (
+        ptc_reform >= ptc_baseline
+    ), f"Reform ({ptc_reform}) should be >= baseline ({ptc_baseline})"
 
     print("✓ Baseline vs reform works")
 
@@ -74,5 +78,6 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n❌ Test failed: {e}")
         import traceback
+
         traceback.print_exc()
         sys.exit(1)

--- a/tests/test_la_county_zip.py
+++ b/tests/test_la_county_zip.py
@@ -1,0 +1,116 @@
+"""
+Test Los Angeles County zip code requirement
+
+LA County has multiple rating areas based on zip code, so PolicyEngine
+requires a zip code to determine the SLCSP rating area.
+"""
+
+import pytest
+from policyengine_us import Simulation
+
+
+def test_la_county_requires_zip_code():
+    """LA County should work with a valid zip code"""
+    situation = {
+        "people": {
+            "you": {"age": {2026: 30}, "employment_income": {2026: 50000}}
+        },
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"your household": {"members": ["you"]}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {
+            "your household": {
+                "members": ["you"],
+                "state_name": {2026: "CA"},
+                "county": {2026: "LOS_ANGELES_COUNTY_CA"},
+                "zip_code": {2026: "90001"},  # South LA zip code
+            }
+        },
+    }
+
+    sim = Simulation(situation=situation)
+
+    # Should be able to calculate SLCSP without error
+    slcsp = sim.calculate("slcsp", map_to="household", period=2026)[0]
+    assert slcsp > 0, "SLCSP should be calculated for LA County with zip code"
+
+    # Should also calculate PTC
+    ptc = sim.calculate("aca_ptc", map_to="household", period=2026)[0]
+    # PTC may or may not be positive depending on SLCSP and income, but should not error
+    assert ptc >= 0
+
+
+def test_la_county_different_zip_codes():
+    """Different LA County zip codes should potentially have different SLCSPs"""
+    # Downtown LA
+    situation_downtown = {
+        "people": {
+            "you": {"age": {2026: 30}, "employment_income": {2026: 40000}}
+        },
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"your household": {"members": ["you"]}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {
+            "your household": {
+                "members": ["you"],
+                "state_name": {2026: "CA"},
+                "county": {2026: "LOS_ANGELES_COUNTY_CA"},
+                "zip_code": {2026: "90012"},  # Downtown LA
+            }
+        },
+    }
+
+    # Santa Monica
+    situation_santa_monica = {
+        "people": {
+            "you": {"age": {2026: 30}, "employment_income": {2026: 40000}}
+        },
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"your household": {"members": ["you"]}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {
+            "your household": {
+                "members": ["you"],
+                "state_name": {2026: "CA"},
+                "county": {2026: "LOS_ANGELES_COUNTY_CA"},
+                "zip_code": {2026: "90401"},  # Santa Monica
+            }
+        },
+    }
+
+    sim1 = Simulation(situation=situation_downtown)
+    sim2 = Simulation(situation=situation_santa_monica)
+
+    slcsp1 = sim1.calculate("slcsp", map_to="household", period=2026)[0]
+    slcsp2 = sim2.calculate("slcsp", map_to="household", period=2026)[0]
+
+    # Both should calculate successfully
+    assert slcsp1 > 0
+    assert slcsp2 > 0
+
+    # They might be different (depending on rating areas) but at least they should both work
+    # Note: We're not asserting they're different because they might be in the same rating area
+
+
+def test_other_california_counties_work_without_zip():
+    """Other CA counties should work without zip code"""
+    situation = {
+        "people": {
+            "you": {"age": {2026: 30}, "employment_income": {2026: 50000}}
+        },
+        "families": {"your family": {"members": ["you"]}},
+        "spm_units": {"your household": {"members": ["you"]}},
+        "tax_units": {"your tax unit": {"members": ["you"]}},
+        "households": {
+            "your household": {
+                "members": ["you"],
+                "state_name": {2026: "CA"},
+                "county": {2026: "ALAMEDA_COUNTY_CA"},
+                # No zip code - should work fine for non-LA counties
+            }
+        },
+    }
+
+    sim = Simulation(situation=situation)
+    slcsp = sim.calculate("slcsp", map_to="household", period=2026)[0]
+    assert slcsp > 0, "Non-LA CA counties should work without zip code"


### PR DESCRIPTION
## Summary
- Adds conditional ZIP code input when Los Angeles County is selected
- LA County has multiple rating areas requiring ZIP code for accurate SLCSP calculations
- Validates ZIP code format (5 digits)
- Increases chart resolution from 1,001 to 10,001 points ($100 increments instead of $1,000)

## Changes
- Added ZIP code input field that appears only when CA + Los Angeles County is selected
- Updated `calculate_ptc()` to accept and pass ZIP code to PolicyEngine
- Updated `create_chart()` to handle ZIP codes for chart generation
- Added comprehensive tests for LA County ZIP code handling
- Fixed existing tests to handle new 4-value return from `calculate_ptc()`
- Improved chart smoothness with 10x more data points

## Test plan
- [x] Tests pass for LA County with ZIP code
- [x] Tests pass for other CA counties without ZIP code
- [x] Different LA County ZIP codes work correctly
- [x] Existing calculate_ptc tests updated and passing
- [x] UI shows ZIP code field only for LA County

🤖 Generated with [Claude Code](https://claude.com/claude-code)