### PR TITLE
Fix chart not updating when inputs change

### DIFF
--- a/app.py
+++ b/app.py
@@ -262,7 +262,7 @@ def main():
 
         if calculate_button:
             st.session_state.calculate = True
-            st.session_state.params = {
+            new_params = {
                 "age_head": age_head,
                 "age_spouse": age_spouse,
                 "dependent_ages": dependent_ages,
@@ -271,6 +271,10 @@ def main():
                 "married": married,
                 "zip_code": zip_code,
             }
+            # Clear cached charts if params changed
+            if hasattr(st.session_state, "params") and st.session_state.params != new_params:
+                st.session_state.income_range = None
+            st.session_state.params = new_params
 
     # Main content area
     if not hasattr(st.session_state, "calculate") or not st.session_state.calculate:


### PR DESCRIPTION
## Summary
Fixes bug where changing household inputs and clicking "Analyze premium subsidies" again didn't regenerate the charts.

## Changes
- Detect when params change by comparing new inputs to stored session state
- Clear cached charts (`income_range = None`) when params differ
- Forces recalculation on next render

## Test plan
- [x] Change age/state/county and click analyze - chart updates
- [x] Change back to original values - chart updates correctly
- [x] Entering income in "Your impact" tab still works instantly (no recalc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)