### PR TITLE
Add net income and marginal tax rate tabs

### DIFF
--- a/app.py
+++ b/app.py
@@ -396,8 +396,15 @@ def main():
                     )
 
             with tab4:
-                # Auto-generate MTR chart if not cached (uses same calculation as net income)
-                if not hasattr(st.session_state, "fig_mtr") or st.session_state.fig_mtr is None:
+                # Display cached chart or generate
+                if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
+                    st.plotly_chart(
+                        st.session_state.fig_mtr,
+                        use_container_width=True,
+                        config={"displayModeBar": False},
+                        key="mtr_chart",
+                    )
+                else:
                     with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
                         x_axis_max = st.session_state.get("x_axis_max", 200000)
                         (
@@ -420,15 +427,13 @@ def main():
                         if fig_mtr is not None:
                             st.session_state.fig_net_income = fig_net_income
                             st.session_state.fig_mtr = fig_mtr
-
-                # Display cached chart
-                if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
-                    st.plotly_chart(
-                        st.session_state.fig_mtr,
-                        use_container_width=True,
-                        config={"displayModeBar": False},
-                        key="mtr_chart",
-                    )
+                            # Show chart immediately
+                            st.plotly_chart(
+                                st.session_state.fig_mtr,
+                                use_container_width=True,
+                                config={"displayModeBar": False},
+                                key="mtr_chart",
+                            )
 
             with tab5:
                 st.markdown("Enter your annual household income to see your specific impact.")
@@ -1455,11 +1460,11 @@ def create_net_income_and_mtr_charts(
 
         # Calculate MTR using numerical differentiation with smoothing
         # MTR = 1 - d(net_income)/d(employment_income)
-        # Use wider window (10 points = $1000) for smoother MTR
+        # Use wider window (50 points = $5000) for smoother MTR
         # Income range has uniform $100 spacing
-        window = 10
-        d_income_central = income_range[window] - income_range[0]  # $1000 for edges
-        d_income_window = 2 * d_income_central  # $2000 for central differences
+        window = 50
+        d_income_central = income_range[window] - income_range[0]  # $5000 for edges
+        d_income_window = 2 * d_income_central  # $10000 for central differences
 
         mtr_baseline = np.zeros_like(income_range)
         mtr_reform = np.zeros_like(income_range)

--- a/app.py
+++ b/app.py
@@ -1523,9 +1523,14 @@ def create_net_income_and_mtr_charts(
             )
         )
 
-        # Set y-axis range to double the max value for better scaling
-        net_income_max = max(np.max(net_income_baseline), np.max(net_income_reform))
-        net_income_y_max = net_income_max * 2
+        # Set y-axis range to 1.2x the max value within visible x range
+        # Find indices within x_axis_max
+        visible_indices = income_range <= x_axis_max
+        net_income_max = max(
+            np.max(net_income_baseline[visible_indices]),
+            np.max(net_income_reform[visible_indices])
+        )
+        net_income_y_max = net_income_max * 1.2
 
         fig_net_income.update_layout(
             title={

--- a/app.py
+++ b/app.py
@@ -1546,6 +1546,10 @@ def create_net_income_and_mtr_charts(
             )
         )
 
+        # Set y-axis range to double the max value for better scaling
+        net_income_max = max(np.max(net_income_baseline), np.max(net_income_reform))
+        net_income_y_max = net_income_max * 2
+
         fig_net_income.update_layout(
             title={
                 "text": "Net income including health benefits (2026)",
@@ -1558,7 +1562,7 @@ def create_net_income_and_mtr_charts(
                 tickformat="$,.0f", range=[0, x_axis_max], automargin=True
             ),
             yaxis=dict(
-                tickformat="$,.0f", automargin=True
+                tickformat="$,.0f", range=[0, net_income_y_max], automargin=True
             ),
             plot_bgcolor="white",
             paper_bgcolor="white",

--- a/app.py
+++ b/app.py
@@ -1589,7 +1589,7 @@ def create_net_income_and_mtr_charts(
                 tickformat="$,.0f", range=[0, x_axis_max], automargin=True
             ),
             yaxis=dict(
-                tickformat=".0f", ticksuffix="%", range=[-20, 100], automargin=True
+                tickformat=".0f", ticksuffix="%", range=[-20, 100], automargin=True, zeroline=True, zerolinecolor="black", zerolinewidth=2
             ),
             plot_bgcolor="white",
             paper_bgcolor="white",

--- a/app.py
+++ b/app.py
@@ -398,33 +398,28 @@ def main():
             with tab4:
                 # Auto-generate MTR chart if not cached (uses same calculation as net income)
                 if not hasattr(st.session_state, "fig_mtr") or st.session_state.fig_mtr is None:
-                    # Check if we already have net income data (they're calculated together)
-                    if hasattr(st.session_state, "fig_net_income") and st.session_state.fig_net_income is not None:
-                        # MTR already calculated with net income
-                        pass
-                    else:
-                        with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
-                            x_axis_max = st.session_state.get("x_axis_max", 200000)
-                            (
-                                fig_net_income,
-                                fig_mtr,
-                                net_income_range,
-                                net_income_baseline,
-                                net_income_reform,
-                            ) = create_net_income_and_mtr_charts(
-                                params["age_head"],
-                                params["age_spouse"],
-                                tuple(params["dependent_ages"]),
-                                params["state"],
-                                params.get("county"),
-                                params.get("zip_code"),
-                                x_axis_max,
-                            )
+                    with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
+                        x_axis_max = st.session_state.get("x_axis_max", 200000)
+                        (
+                            fig_net_income,
+                            fig_mtr,
+                            net_income_range,
+                            net_income_baseline,
+                            net_income_reform,
+                        ) = create_net_income_and_mtr_charts(
+                            params["age_head"],
+                            params["age_spouse"],
+                            tuple(params["dependent_ages"]),
+                            params["state"],
+                            params.get("county"),
+                            params.get("zip_code"),
+                            x_axis_max,
+                        )
 
-                            # Store in session state
-                            if fig_mtr is not None:
-                                st.session_state.fig_net_income = fig_net_income
-                                st.session_state.fig_mtr = fig_mtr
+                        # Store in session state
+                        if fig_mtr is not None:
+                            st.session_state.fig_net_income = fig_net_income
+                            st.session_state.fig_mtr = fig_mtr
 
                 # Display cached chart
                 if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
@@ -1613,7 +1608,7 @@ def create_net_income_and_mtr_charts(
                 tickformat="$,.0f", range=[0, x_axis_max], automargin=True
             ),
             yaxis=dict(
-                tickformat=".0f", ticksuffix="%", automargin=True
+                tickformat=".0f", ticksuffix="%", range=[-20, 100], automargin=True
             ),
             plot_bgcolor="white",
             paper_bgcolor="white",

--- a/app.py
+++ b/app.py
@@ -341,9 +341,9 @@ def main():
             tab1, tab2, tab3, tab4, tab5 = st.tabs([
                 "Gain from extension",
                 "Baseline vs. extension",
-                "Your impact",
                 "Net income",
-                "Marginal tax rates"
+                "Marginal tax rates",
+                "Your impact"
             ])
 
             with tab1:
@@ -361,6 +361,74 @@ def main():
                 )
 
             with tab3:
+                # Auto-generate net income chart if not cached
+                if not hasattr(st.session_state, "fig_net_income") or st.session_state.fig_net_income is None:
+                    with st.spinner("Calculating net income (this may take a few seconds)..."):
+                        x_axis_max = st.session_state.get("x_axis_max", 200000)
+                        (
+                            fig_net_income,
+                            fig_mtr,
+                            net_income_range,
+                            net_income_baseline,
+                            net_income_reform,
+                        ) = create_net_income_and_mtr_charts(
+                            params["age_head"],
+                            params["age_spouse"],
+                            tuple(params["dependent_ages"]),
+                            params["state"],
+                            params.get("county"),
+                            params.get("zip_code"),
+                            x_axis_max,
+                        )
+
+                        # Store in session state
+                        if fig_net_income is not None:
+                            st.session_state.fig_net_income = fig_net_income
+                            st.session_state.fig_mtr = fig_mtr
+
+                # Display cached chart
+                if hasattr(st.session_state, "fig_net_income") and st.session_state.fig_net_income is not None:
+                    st.plotly_chart(
+                        st.session_state.fig_net_income,
+                        use_container_width=True,
+                        config={"displayModeBar": False},
+                    )
+
+            with tab4:
+                # Auto-generate MTR chart if not cached (uses same calculation as net income)
+                if not hasattr(st.session_state, "fig_mtr") or st.session_state.fig_mtr is None:
+                    with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
+                        x_axis_max = st.session_state.get("x_axis_max", 200000)
+                        (
+                            fig_net_income,
+                            fig_mtr,
+                            net_income_range,
+                            net_income_baseline,
+                            net_income_reform,
+                        ) = create_net_income_and_mtr_charts(
+                            params["age_head"],
+                            params["age_spouse"],
+                            tuple(params["dependent_ages"]),
+                            params["state"],
+                            params.get("county"),
+                            params.get("zip_code"),
+                            x_axis_max,
+                        )
+
+                        # Store in session state
+                        if fig_mtr is not None:
+                            st.session_state.fig_net_income = fig_net_income
+                            st.session_state.fig_mtr = fig_mtr
+
+                # Display cached chart
+                if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
+                    st.plotly_chart(
+                        st.session_state.fig_mtr,
+                        use_container_width=True,
+                        config={"displayModeBar": False},
+                    )
+
+            with tab5:
                 st.markdown("Enter your annual household income to see your specific impact.")
 
                 user_income = st.number_input(

--- a/app.py
+++ b/app.py
@@ -338,11 +338,9 @@ def main():
 
         # Show tabs using cached charts
         if hasattr(st.session_state, "fig_delta") and st.session_state.fig_delta is not None:
-            tab1, tab2, tab3, tab4, tab5 = st.tabs([
+            tab1, tab2, tab3 = st.tabs([
                 "Gain from extension",
                 "Baseline vs. extension",
-                "Net income",
-                "Marginal tax rates",
                 "Your impact"
             ])
 
@@ -361,81 +359,6 @@ def main():
                 )
 
             with tab3:
-                # Auto-generate net income chart if not cached
-                if not hasattr(st.session_state, "fig_net_income") or st.session_state.fig_net_income is None:
-                    with st.spinner("Calculating net income (this may take a few seconds)..."):
-                        x_axis_max = st.session_state.get("x_axis_max", 200000)
-                        (
-                            fig_net_income,
-                            fig_mtr,
-                            net_income_range,
-                            net_income_baseline,
-                            net_income_reform,
-                        ) = create_net_income_and_mtr_charts(
-                            params["age_head"],
-                            params["age_spouse"],
-                            tuple(params["dependent_ages"]),
-                            params["state"],
-                            params.get("county"),
-                            params.get("zip_code"),
-                            x_axis_max,
-                        )
-
-                        # Store in session state
-                        if fig_net_income is not None:
-                            st.session_state.fig_net_income = fig_net_income
-                            st.session_state.fig_mtr = fig_mtr
-
-                # Display cached chart
-                if hasattr(st.session_state, "fig_net_income") and st.session_state.fig_net_income is not None:
-                    st.plotly_chart(
-                        st.session_state.fig_net_income,
-                        use_container_width=True,
-                        config={"displayModeBar": False},
-                        key="net_income_chart",
-                    )
-
-            with tab4:
-                # Display cached chart or generate
-                if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
-                    st.plotly_chart(
-                        st.session_state.fig_mtr,
-                        use_container_width=True,
-                        config={"displayModeBar": False},
-                        key="mtr_chart",
-                    )
-                else:
-                    with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
-                        x_axis_max = st.session_state.get("x_axis_max", 200000)
-                        (
-                            fig_net_income,
-                            fig_mtr,
-                            net_income_range,
-                            net_income_baseline,
-                            net_income_reform,
-                        ) = create_net_income_and_mtr_charts(
-                            params["age_head"],
-                            params["age_spouse"],
-                            tuple(params["dependent_ages"]),
-                            params["state"],
-                            params.get("county"),
-                            params.get("zip_code"),
-                            x_axis_max,
-                        )
-
-                        # Store in session state
-                        if fig_mtr is not None:
-                            st.session_state.fig_net_income = fig_net_income
-                            st.session_state.fig_mtr = fig_mtr
-                            # Show chart immediately
-                            st.plotly_chart(
-                                st.session_state.fig_mtr,
-                                use_container_width=True,
-                                config={"displayModeBar": False},
-                                key="mtr_chart",
-                            )
-
-            with tab5:
                 st.markdown("Enter your annual household income to see your specific impact.")
 
                 user_income = st.number_input(

--- a/app.py
+++ b/app.py
@@ -1511,37 +1511,12 @@ def create_net_income_and_mtr_charts(
         )
 
         # Calculate net income including health benefits
-        # Net income = household_net_income + aca_ptc + medicaid_cost + per_capita_chip
-        net_income_baseline_core = sim_baseline.calculate(
-            "household_net_income", map_to="household", period=2026
+        # Use PolicyEngine's built-in variable that includes PTCs, Medicaid, CHIP
+        net_income_baseline = sim_baseline.calculate(
+            "household_net_income_including_health_benefits", map_to="household", period=2026
         )
-        aca_ptc_baseline = sim_baseline.calculate(
-            "aca_ptc", map_to="household", period=2026
-        )
-        medicaid_baseline = sim_baseline.calculate(
-            "medicaid_cost", map_to="household", period=2026
-        )
-        chip_baseline = sim_baseline.calculate(
-            "per_capita_chip", map_to="household", period=2026
-        )
-        net_income_baseline = (
-            net_income_baseline_core + aca_ptc_baseline + medicaid_baseline + chip_baseline
-        )
-
-        net_income_reform_core = sim_reform.calculate(
-            "household_net_income", map_to="household", period=2026
-        )
-        aca_ptc_reform = sim_reform.calculate(
-            "aca_ptc", map_to="household", period=2026
-        )
-        medicaid_reform = sim_reform.calculate(
-            "medicaid_cost", map_to="household", period=2026
-        )
-        chip_reform = sim_reform.calculate(
-            "per_capita_chip", map_to="household", period=2026
-        )
-        net_income_reform = (
-            net_income_reform_core + aca_ptc_reform + medicaid_reform + chip_reform
+        net_income_reform = sim_reform.calculate(
+            "household_net_income_including_health_benefits", map_to="household", period=2026
         )
 
         # Calculate MTR using numerical differentiation with smoothing

--- a/app.py
+++ b/app.py
@@ -392,33 +392,39 @@ def main():
                         st.session_state.fig_net_income,
                         use_container_width=True,
                         config={"displayModeBar": False},
+                        key="net_income_chart",
                     )
 
             with tab4:
                 # Auto-generate MTR chart if not cached (uses same calculation as net income)
                 if not hasattr(st.session_state, "fig_mtr") or st.session_state.fig_mtr is None:
-                    with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
-                        x_axis_max = st.session_state.get("x_axis_max", 200000)
-                        (
-                            fig_net_income,
-                            fig_mtr,
-                            net_income_range,
-                            net_income_baseline,
-                            net_income_reform,
-                        ) = create_net_income_and_mtr_charts(
-                            params["age_head"],
-                            params["age_spouse"],
-                            tuple(params["dependent_ages"]),
-                            params["state"],
-                            params.get("county"),
-                            params.get("zip_code"),
-                            x_axis_max,
-                        )
+                    # Check if we already have net income data (they're calculated together)
+                    if hasattr(st.session_state, "fig_net_income") and st.session_state.fig_net_income is not None:
+                        # MTR already calculated with net income
+                        pass
+                    else:
+                        with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
+                            x_axis_max = st.session_state.get("x_axis_max", 200000)
+                            (
+                                fig_net_income,
+                                fig_mtr,
+                                net_income_range,
+                                net_income_baseline,
+                                net_income_reform,
+                            ) = create_net_income_and_mtr_charts(
+                                params["age_head"],
+                                params["age_spouse"],
+                                tuple(params["dependent_ages"]),
+                                params["state"],
+                                params.get("county"),
+                                params.get("zip_code"),
+                                x_axis_max,
+                            )
 
-                        # Store in session state
-                        if fig_mtr is not None:
-                            st.session_state.fig_net_income = fig_net_income
-                            st.session_state.fig_mtr = fig_mtr
+                            # Store in session state
+                            if fig_mtr is not None:
+                                st.session_state.fig_net_income = fig_net_income
+                                st.session_state.fig_mtr = fig_mtr
 
                 # Display cached chart
                 if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
@@ -426,6 +432,7 @@ def main():
                         st.session_state.fig_mtr,
                         use_container_width=True,
                         config={"displayModeBar": False},
+                        key="mtr_chart",
                     )
 
             with tab5:
@@ -537,74 +544,6 @@ def main():
                         If the benchmark plan costs less than your required contribution, you get no credit.
                         """
                         )
-
-            with tab4:
-                # Auto-generate net income chart if not cached
-                if not hasattr(st.session_state, "fig_net_income") or st.session_state.fig_net_income is None:
-                    with st.spinner("Calculating net income (this may take a few seconds)..."):
-                        x_axis_max = st.session_state.get("x_axis_max", 200000)
-                        (
-                            fig_net_income,
-                            fig_mtr,
-                            net_income_range,
-                            net_income_baseline,
-                            net_income_reform,
-                        ) = create_net_income_and_mtr_charts(
-                            params["age_head"],
-                            params["age_spouse"],
-                            tuple(params["dependent_ages"]),
-                            params["state"],
-                            params.get("county"),
-                            params.get("zip_code"),
-                            x_axis_max,
-                        )
-
-                        # Store in session state
-                        if fig_net_income is not None:
-                            st.session_state.fig_net_income = fig_net_income
-                            st.session_state.fig_mtr = fig_mtr
-
-                # Display cached chart
-                if hasattr(st.session_state, "fig_net_income") and st.session_state.fig_net_income is not None:
-                    st.plotly_chart(
-                        st.session_state.fig_net_income,
-                        use_container_width=True,
-                        config={"displayModeBar": False},
-                    )
-
-            with tab5:
-                # Auto-generate MTR chart if not cached (uses same calculation as net income)
-                if not hasattr(st.session_state, "fig_mtr") or st.session_state.fig_mtr is None:
-                    with st.spinner("Calculating marginal tax rates (this may take a few seconds)..."):
-                        x_axis_max = st.session_state.get("x_axis_max", 200000)
-                        (
-                            fig_net_income,
-                            fig_mtr,
-                            net_income_range,
-                            net_income_baseline,
-                            net_income_reform,
-                        ) = create_net_income_and_mtr_charts(
-                            params["age_head"],
-                            params["age_spouse"],
-                            tuple(params["dependent_ages"]),
-                            params["state"],
-                            params.get("county"),
-                            params.get("zip_code"),
-                            x_axis_max,
-                        )
-
-                        # Store in session state
-                        if fig_mtr is not None:
-                            st.session_state.fig_net_income = fig_net_income
-                            st.session_state.fig_mtr = fig_mtr
-
-                # Display cached chart
-                if hasattr(st.session_state, "fig_mtr") and st.session_state.fig_mtr is not None:
-                    st.plotly_chart(
-                        st.session_state.fig_mtr,
-                        use_container_width=True,
-                        config={"displayModeBar": False},
-                    )
 
             # Move "About this calculator" below the tabs
             with st.expander("About this calculator"):

--- a/app.py
+++ b/app.py
@@ -1510,12 +1510,19 @@ def create_net_income_and_mtr_charts(
                 text += "<b>No difference</b>"
             net_income_hover.append(text)
 
-        # Create MTR hover text
+        # Create MTR hover text with PTC diagnostic info
         mtr_hover = []
         for i in range(len(income_range)):
             text = f"<b>Income: ${income_range[i]:,.0f}</b><br><br>"
-            text += f"<b>MTR (current law):</b> {mtr_baseline_viz[i]*100:.1f}%<br>"
-            text += f"<b>MTR (extended):</b> {mtr_reform_viz[i]*100:.1f}%<br>"
+            text += f"<b>PTC (current law):</b> ${ptc_baseline[i]:,.0f}<br>"
+            text += f"<b>PTC (extended):</b> ${ptc_reform[i]:,.0f}<br>"
+            if i > 0:
+                d_ptc_base = ptc_baseline[i] - ptc_baseline[i-1]
+                d_ptc_ref = ptc_reform[i] - ptc_reform[i-1]
+                text += f"<b>PTC change (current):</b> ${d_ptc_base:+.0f}<br>"
+                text += f"<b>PTC change (extended):</b> ${d_ptc_ref:+.0f}<br>"
+            text += f"<b>PTC MTR (current law):</b> {mtr_baseline_viz[i]*100:.1f}%<br>"
+            text += f"<b>PTC MTR (extended):</b> {mtr_reform_viz[i]*100:.1f}%<br>"
             diff = (mtr_reform_viz[i] - mtr_baseline_viz[i]) * 100
             if abs(diff) > 0.1:
                 text += f"<b>Difference:</b> {diff:+.1f} pp"

--- a/app.py
+++ b/app.py
@@ -1459,13 +1459,17 @@ def create_net_income_and_mtr_charts(
         )
 
         # Calculate MTR using PolicyEngine's built-in variable
-        # This properly handles cliffs and discontinuities
-        mtr_baseline = sim_baseline.calculate(
-            "marginal_tax_rate_including_health_benefits", map_to="household", period=2026
+        # Get MTR for first person (head of household) only, not summed across all people
+        mtr_baseline_all = sim_baseline.calculate(
+            "marginal_tax_rate_including_health_benefits", period=2026
         )
-        mtr_reform = sim_reform.calculate(
-            "marginal_tax_rate_including_health_benefits", map_to="household", period=2026
+        mtr_reform_all = sim_reform.calculate(
+            "marginal_tax_rate_including_health_benefits", period=2026
         )
+
+        # Extract head of household MTR (first person in axes)
+        mtr_baseline = mtr_baseline_all[0]  # First person = "you"
+        mtr_reform = mtr_reform_all[0]
 
         # Convert to percentage (variable is already in 0-1 range)
         mtr_baseline_pct = mtr_baseline * 100

--- a/tests/test_mtr_calculation.py
+++ b/tests/test_mtr_calculation.py
@@ -1,0 +1,53 @@
+"""Test MTR calculation is correct"""
+import pytest
+import numpy as np
+from policyengine_us import Simulation
+
+
+def test_mtr_positive_for_typical_household():
+    """MTR should be positive for most income levels"""
+    situation = {
+        "people": {"you": {"age": {2026: 60}}},
+        "families": {"family": {"members": ["you"]}},
+        "spm_units": {"household": {"members": ["you"]}},
+        "tax_units": {"tax_unit": {"members": ["you"]}},
+        "marital_units": {"marital_unit": {"members": ["you"]}},
+        "households": {
+            "household": {
+                "members": ["you"],
+                "state_name": {2026: "AK"},
+            }
+        },
+        "axes": [[{"name": "employment_income", "count": 101, "min": 0, "max": 100000, "period": 2026}]]
+    }
+
+    sim = Simulation(situation=situation)
+    
+    income = sim.calculate("employment_income", map_to="household", period=2026)
+    net_income = sim.calculate("household_net_income_including_health_benefits", map_to="household", period=2026)
+    
+    # Calculate MTR at income=$50k (index 50)
+    i = 50
+    window = 10
+    d_income = income[i+window] - income[i-window]
+    d_net = net_income[i+window] - net_income[i-window]
+    mtr = 1 - d_net / d_income
+    
+    # MTR should be positive (between 0 and 100%)
+    assert mtr > 0, f"MTR is negative: {mtr*100:.1f}%"
+    assert mtr < 1, f"MTR exceeds 100%: {mtr*100:.1f}%"
+    
+    print(f"MTR at $50k income: {mtr*100:.1f}%")
+    
+
+def test_mtr_formula():
+    """Verify MTR formula: MTR = 1 - d(net)/d(gross)"""
+    # Simple case: if net income goes up by $700 when gross goes up by $1000
+    # Then MTR = 1 - 700/1000 = 0.30 = 30%
+    
+    d_gross = 1000
+    d_net = 700
+    mtr = 1 - d_net / d_gross
+    
+    assert abs(mtr - 0.30) < 0.0001, f"MTR formula incorrect: {mtr}"
+    print("MTR formula verified: 30% MTR when keeping 70 cents per dollar")


### PR DESCRIPTION
## Summary
Temporarily hides Net income and Marginal tax rates tabs while we refactor the codebase into a proper package structure.

## Changes
- Remove Net income and Marginal tax rates tabs from UI
- Keep create_net_income_and_mtr_charts() function for future use
- Back to 3 tabs: Gain from extension, Baseline vs. extension, Your impact

## Why hiding
The MTR chart shows spikes that need investigation. Rather than debug in the monolithic app.py, we'll:
1. Merge this to hide the incomplete features
2. Refactor into proper package structure (aca_calc/calculations/)
3. Add comprehensive tests
4. Debug MTR spikes with TDD
5. Re-add tabs in future PR when working correctly

## Test plan
- [x] Only 3 tabs show
- [x] App works as before
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)