### PR TITLE
Fix duplicate plotly_chart element ID error on Streamlit Cloud

### DIFF
--- a/app.py
+++ b/app.py
@@ -356,6 +356,7 @@ def main():
                     st.session_state.fig_delta,
                     use_container_width=True,
                     config={"displayModeBar": False},
+                    key="gain_chart",
                 )
 
             with tab2:
@@ -363,6 +364,7 @@ def main():
                     st.session_state.fig_comparison,
                     use_container_width=True,
                     config={"displayModeBar": False},
+                    key="comparison_chart",
                 )
 
             with tab3:


### PR DESCRIPTION
## Summary
Fixes production error on Streamlit Cloud caused by duplicate plotly_chart element IDs.

## Error
```
streamlit.errors.StreamlitDuplicateElementId: There are multiple plotly_chart 
elements with the same auto-generated ID.
```

## Root cause
The first two plotly_chart calls (gain and comparison charts) were missing unique `key` parameters. Streamlit Cloud's stricter element ID validation caught this, while local development didn't.

## Fix
Add unique keys to all plotly_chart elements:
- `key="gain_chart"` for tab1 (Gain from extension)
- `key="comparison_chart"` for tab2 (Baseline vs. extension)
- Net income and MTR charts already had keys

## Why local vs Cloud differed
- Different Streamlit versions or session state handling
- Cloud environment more strict about element IDs
- Good practice to always include keys anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)