### PR TITLE
Add PolicyEngine header to multizone shell

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,4 +1,5 @@
 import "./globals.css";
+import PolicyEngineHeader from "../components/PolicyEngineHeader";
 
 export const metadata = {
   title: "ACA Calculator",
@@ -8,7 +9,10 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PolicyEngineHeader />
+        {children}
+      </body>
     </html>
   );
 }

--- a/components/PolicyEngineHeader.jsx
+++ b/components/PolicyEngineHeader.jsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Header } from "@policyengine/ui-kit";
+
+const navItems = [
+  { label: "Research", href: "https://policyengine.org/us/research" },
+  { label: "Model", href: "https://policyengine.org/us/model" },
+  { label: "API", href: "https://policyengine.org/us/api" },
+  {
+    label: "About",
+    href: "https://policyengine.org/us/team",
+    children: [
+      { label: "Team", href: "https://policyengine.org/us/team" },
+      { label: "Supporters", href: "https://policyengine.org/us/supporters" },
+    ],
+  },
+  { label: "Donate", href: "https://policyengine.org/us/donate" },
+];
+
+const countries = [
+  { id: "us", label: "United States" },
+  { id: "uk", label: "United Kingdom" },
+];
+
+export default function PolicyEngineHeader() {
+  return (
+    <Header
+      navItems={navItems}
+      countries={countries}
+      currentCountry="us"
+      logoHref="https://policyengine.org/us"
+      onCountryChange={(countryId) => {
+        window.location.href = `https://policyengine.org/${countryId}`;
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary\n- render the shared @policyengine/ui-kit Header above the ACA calculator\n- keep the multizone route iframe-free while restoring PolicyEngine site chrome\n\n## Verification\n- bun install --frozen-lockfile\n- bun run build\n