### PR TITLE
Wrap layout with @policyengine/ui-kit PolicyEngineShell

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,3 +1,6 @@
+import { PolicyEngineShell } from "@policyengine/ui-kit/layout";
+import "@policyengine/ui-kit/styles.css";
+
 import "./globals.css";
 
 export const metadata = {
@@ -8,7 +11,9 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <PolicyEngineShell country="us">{children}        </PolicyEngineShell>
+      </body>
     </html>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "aca-scrollytelling",
       "dependencies": {
-        "@policyengine/ui-kit": "^0.9.0",
+        "@policyengine/ui-kit": "^0.12.0",
         "d3": "^7.9.0",
         "next": "^16.2.6",
         "react": "^19.2.0",
@@ -113,7 +113,7 @@
 
     "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@16.2.6", "", { "os": "win32", "cpu": "x64" }, "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA=="],
 
-    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.9.1", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-wigj/WodytMGqW8n02IKda2uYVxzBE3iDqzRweDJn+4VZQqb02rCf1TBqsM9WGslkPAetavjAoQrBCVnGZQEKQ=="],
+    "@policyengine/ui-kit": ["@policyengine/ui-kit@0.12.0", "", { "dependencies": { "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "d3-geo": "^3.1.0", "dayjs": "^1.11.13", "lucide-react": "^0.577.0", "radix-ui": "^1.4.3", "tailwind-merge": "^3.5.0", "tw-animate-css": "^1.4.0" }, "peerDependencies": { "react": ">=19", "react-dom": ">=19", "recharts": ">=2.12" } }, "sha512-Psz6j9ykKjGzrvEHR2Evv1EbOS/H7eBM5iydd7GfxCD2eQgu6uMWw2sLZXNFfmhKKDxevheynnaATcKJOw5QGQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@policyengine/ui-kit": "^0.9.0",
+    "@policyengine/ui-kit": "^0.12.0",
     "d3": "^7.9.0",
     "next": "^16.2.6",
     "react": "^19.2.0",


### PR DESCRIPTION
Wraps the app's root layout with `<PolicyEngineShell country="us">` from `@policyengine/ui-kit ^0.12.0` so policyengine.org/us/* renders the PolicyEngine site header + footer around this tool. Adds the ui-kit dependency. Layout edit is mechanical and idempotent.